### PR TITLE
disable maybe-uninitialized and stringop-overread warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,4 @@ idf_component_register(SRCS ${srcs}
 
 target_compile_options(${COMPONENT_LIB} PRIVATE -DHAVE_ALLOCA_H -DHAVE_LRINT 
 	-DHAVE_LRINTF -DFIXED_POINT -DDISABLE_FLOAT_API -DHAVE_MEMORY_H -DUSE_ALLOCA
-	-DOPUS_BUILD -O2)
+	-DOPUS_BUILD -O2 -Wno-error=maybe-uninitialized -Wno-error=stringop-overread)


### PR DESCRIPTION
This fixes build errors which occur on the esp-adf v2.7 release